### PR TITLE
Improve UI navigation and dashboard polish

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": "next/core-web-vitals"
+}

--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,14 @@ Thumbs.db
 *.avi
 *.mkv
 
+# Node/Next outputs
+node_modules/
+.next/
+out/
+dev.db
+*.sqlite
+*.db-journal
+
 # Ignore logs and temp files
 *.log
 *.tmp

--- a/README.md
+++ b/README.md
@@ -1,128 +1,64 @@
-# Adobe Stock 出品パイプライン運用マニュアル
+# Product Intelligence OS (v1.0)
 
----
+A Next.js + Prisma + SQLite toolkit to log daily KPIs across YouTube / note / apps / music, benchmark performance, capture quality gate results, and propose replicate / improve / freeze decisions.
 
-## 目的
-Runway Gen‑4 で生成した 10 s MP4 を、4 K60 fps の 10 s／20 s／30 s 完全ループに変換し、Adobe Stock へ最短で提出できるファイル一式（MP4 + compliance.json + metadata.json + ZIP）を自動生成する。
+## Features
+- Prisma schema exactly matching the v1.0 spec (Product / Asset / MetricDaily / CostDaily / QualityGateLog / TrendDaily / Decision / Template + enums).
+- Screens (App Router): Overview, Products, Product Detail, Assets, Asset Detail, Compare, Trends, Decisions, Templates, Import.
+- CSV import for metrics, costs, trends, and quality gate logs (server actions).
+- Benchmarking (BenchA/B) with decision proposals and approval flow that writes to `Decision`.
+- Recharts visualizations for key KPIs on overview, product, and asset pages.
+- Trend × Template candidate list generation.
+- HTTP endpoint `POST /api/gates` for QualityGateLog ingestion.
+- Seed data for products/templates plus a few sample assets/metrics/gates.
 
----
+## Getting started
+1. Install dependencies (from the repo root):
+   ```bash
+   npm install
+   ```
+2. Set up the database and Prisma client:
+   ```bash
+   npx prisma generate
+   npx prisma db push
+   npx prisma db seed
+   ```
+3. Run the app:
+   ```bash
+   npm run dev
+   ```
+   The UI is available at http://localhost:3000.
 
-## 1. 環境前提
+> SQLite lives at `prisma/dev.db` (ignored by git). To reset data, delete the file and rerun the push/seed commands.
 
-| 項目           | 推奨値                                    |
-|----------------|-------------------------------------------|
-| OS             | Ubuntu 20.04 LTS (vast.ai コンテナ)        |
-| シェル         | bash 5.x                                  |
-| 必須パッケージ | ffmpeg 4.2+ / tesseract‑ocr               |
-| Python         | 3.8 以上 (+ pytesseract / opencv‑python / Pillow) |
+## CSV import formats
+Upload from the **Import** screen (four separate forms). Headers must match:
+- **metrics_daily**: `product_id,asset_id,date,metric_key,value,source`
+- **trends_daily**: `date,source,topic,score,region,notes`
+- **costs_daily**: `product_id,asset_id,date,minutes,yen,notes`
+- **gates**: `asset_id,date,stage,result,failCode,severity,hint,gateVersion`
 
-**依存インストール (初回のみ)**
-```bash
-apt update -qq && apt install -y ffmpeg tesseract-ocr \
-  && pip3 install -q --upgrade pytesseract opencv-python pillow
-```
+## Decision rules (v1)
+- **BenchA**: same segment + template, last N=10, top 20% median.
+- **BenchB**: same product, last N=10 median.
+- **replicate** when KPI1+KPI2 ≥ BenchA and gate fail rate < 10%.
+- **improve** when either KPI < BenchB or gate fail rate ≥ 20%.
+- **freeze** when the last two runs are both below BenchB for both KPIs.
 
----
+## API
+- `POST /api/gates`
+  ```json
+  {
+    "assetId": "yt_ai_ep01",
+    "date": "2025-01-10",
+    "stage": "script",
+    "result": "pass",
+    "failCode": "optional",
+    "severity": "high/mid/low",
+    "hint": "optional",
+    "gateVersion": "v1"
+  }
+  ```
 
-## 2. フォルダ構成
-
-```
-/workspace/
-├─ run_pipeline.sh          ← 自動化スクリプト (実行用)
-├─ 01_runway_gen4/          ← Runway 出力 MP4 を置く
-├─ 02_processed/            ← 変換済み MP4 & compliance.json
-├─ 03_publish/              ← ZIP バンドル (動画 + compliance)
-├─ metadata/                ← metadata.json
-└─ logs/                    ← 実行ログ (任意)
-```
-
-> **ポイント**: 作業ルートは常に `/workspace` と固定する。
-
----
-
-## 3. 運用フロー
-
-### STEP 0  スクリプト配置
-
-```bash
-cd /workspace
-# — コピー & ペーストでスクリプトを作成
-cat > run_pipeline.sh <<'EOF'
-…(スクリプト全文。最新版を貼り付け) …
-EOF
-chmod +x run_pipeline.sh
-```
-
-### STEP 1  Runway 動画を配置
-
-```
-/workspace/01_runway_gen4/
-   ├─ hud_teal_10s.mp4        ← 10 s / 16:9 / 24 fps
-   └─ …
-```
-
-- ファイル名は英数字＋アンダースコア推奨。
-- スクリプトが自動で安全リネームするので、空白や日本語が混ざっていても可。
-
-### STEP 2  パイプライン実行
-
-```bash
-/workspace/run_pipeline.sh
-```
-
-**進捗表示例:**
-```
-[1/3] ▶ hud_teal_10s
-frame= 599 fps=150 time=00:00:09.98 …
-✅ 完了 → 10s / 20s / 30s 出力
-```
-
-- 完了後 : `/workspace/02_processed/` に 3 尺×4 K60 fps ファイルと compliance.json が生成。
-
-### STEP 3  Adobe Stock へ提出
-
-- Contributor Portal → Upload
-- `02_processed/hud_teal_10s_loop10s_4k60.mp4` または `03_publish/hud_teal_10s_bundle.zip` をドラッグ
-- 右欄で `metadata/hud_teal_10s.json` を開き、Title / Description / Keywords をコピペ
-- Category = Motion Graphics > Abstract を選択
-- AI‑generated を ON → Submit
-
----
-
-## 4. トラブルシューティング
-
-| 症状 | 原因 / 対策 |
-|------|-------------|
-| スクリプト実行しても何も起きない | 01_runway_gen4 に mp4 が無い。パスを確認。 |
-| "No such file or directory" | スクリプト貼り付け時に EOF 行が抜けた。再作成する。 |
-| 再生できない／黒画面 | ffmpeg バージョン不足 ⇒ apt upgrade ffmpeg |
-| OCR WARN が出る | 発光ラインを文字誤検知。シームレス生成は問題なし (審査には影響しない)。 |
-| 20 s / 30 s が出ない | 途中で Ctrl+C で停止。rm 02_processed/* → スクリプト再実行。 |
-
----
-
-## 5. バージョン管理
-
-| ファイル             | 説明                                     |
-|----------------------|------------------------------------------|
-| run_pipeline_v1.sh   | 最小版 (10 s のみ)                       |
-| run_pipeline_v2.sh   | 10 s + OCR + metadata                    |
-| run_pipeline_v3.sh   | 最新 : 10 s / 20 s / 30 s + ZIP (デフォルト) |
-
-- バージョンタグを付けて保管し、不具合時は前版に切替可。
-
----
-
-## 6. よくある Q&A
-
-- **Q. ループがカクつく**  → **A.** duration=0.5 に変更して再エンコード。
-- **Q. 複数カラーを一括処理したい**  → **A.** 同じフォルダに MP4 を追加して再実行。既存ファイルはスキップ。
-
----
-
-## チェックリスト (提出前)
-
-
----
-
-最終更新: 2025‑05‑11
+## Seed data
+`prisma/seed.ts` preloads the six example products and four templates from the spec, plus sample assets/metrics/trends/decisions so the UI renders immediately.

--- a/app/api/gates/route.ts
+++ b/app/api/gates/route.ts
@@ -1,0 +1,30 @@
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { GateResult, GateStage } from "@prisma/client";
+
+export async function POST(request: Request) {
+  try {
+    const body = await request.json();
+    const { assetId, date, stage, result, failCode, severity, hint, gateVersion } = body;
+    if (!assetId || !date || !stage || !result) {
+      return NextResponse.json({ error: "Missing required fields" }, { status: 400 });
+    }
+    await prisma.qualityGateLog.create({
+      data: {
+        id: crypto.randomUUID(),
+        assetId,
+        date: new Date(date),
+        stage: stage as GateStage,
+        result: result as GateResult,
+        failCode,
+        severity,
+        hint,
+        gateVersion,
+      },
+    });
+    return NextResponse.json({ status: "ok" });
+  } catch (error) {
+    console.error(error);
+    return NextResponse.json({ error: "Unexpected error" }, { status: 500 });
+  }
+}

--- a/app/assets/[id]/page.tsx
+++ b/app/assets/[id]/page.tsx
@@ -1,0 +1,174 @@
+import { MetricChart } from "@/components/MetricChart";
+import { approveProposal } from "@/lib/actions";
+import { createDecision, createMetric, createQualityGateLog } from "@/lib/actions";
+import { buildProposal } from "@/lib/benchmarks";
+import { getKpiPair, metricLabel } from "@/lib/kpis";
+import { prisma } from "@/lib/prisma";
+import { DecisionAction, GateResult, GateStage, MetricKey, ProductKind } from "@prisma/client";
+import { notFound } from "next/navigation";
+
+function series(metrics: { metricKey: MetricKey; value: number; date: Date }[], key: MetricKey) {
+  return metrics
+    .filter((m) => m.metricKey === key)
+    .sort((a, b) => a.date.getTime() - b.date.getTime())
+    .map((m) => ({ date: m.date.toISOString().slice(0, 10), value: m.value }));
+}
+
+export default async function AssetDetail({ params }: { params: { id: string } }) {
+  const asset = await prisma.asset.findUnique({
+    where: { id: params.id },
+    include: {
+      product: true,
+      metrics: true,
+      gateLogs: true,
+    },
+  });
+  if (!asset || !asset.product) return notFound();
+
+  const [k1, k2] = getKpiPair(asset.product.kind as ProductKind);
+  const s1 = series(asset.metrics, k1);
+  const s2 = series(asset.metrics, k2);
+  const decisions = await prisma.decision.findMany({
+    where: { targetId: asset.id },
+    orderBy: { date: "desc" },
+  });
+
+  const proposal = await buildProposal(asset, asset.product);
+
+  async function approveAction() {
+    "use server";
+    await approveProposal(asset.id);
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-semibold">{asset.title}</h1>
+          <p className="text-sm text-slate-500">{asset.product.name} / tpl: {asset.templateId ?? "-"}</p>
+        </div>
+        <form action={approveAction}>
+          <button type="submit" className="rounded bg-emerald-700 px-4 py-2 text-white">Approve proposal</button>
+        </form>
+      </div>
+
+      <div className="grid gap-4 md:grid-cols-2">
+        <MetricChart title={metricLabel(k1)} data={s1} />
+        <MetricChart title={metricLabel(k2)} data={s2} />
+      </div>
+
+      <div className="card">
+        <h2 className="section-title">Proposal</h2>
+        <p className="font-semibold">Suggested: {proposal.suggestedAction ?? "none"}</p>
+        <p className="text-sm text-slate-600">{proposal.reason ?? "Waiting for more data"}</p>
+        <div className="text-xs text-slate-500 mt-2">Gate fail rate: {(proposal.failRate * 100).toFixed(1)}%</div>
+        <div className="mt-3 grid gap-2 md:grid-cols-2">
+          {[k1, k2].map((key) => (
+            <div key={key} className="rounded border border-slate-200 p-2 text-sm">
+              <div className="font-medium">{metricLabel(key)}</div>
+              <div>Latest: {proposal.benchmarks[key].latest ?? "-"}</div>
+              <div>BenchA: {proposal.benchmarks[key].benchA ?? "-"}</div>
+              <div>BenchB: {proposal.benchmarks[key].benchB ?? "-"}</div>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      <div className="grid gap-4 md:grid-cols-2">
+        <div className="card">
+          <h2 className="section-title">Quality gate logs</h2>
+          <div className="space-y-2">
+            {asset.gateLogs.map((log) => (
+              <div key={log.id} className="rounded border border-slate-200 px-3 py-2 text-sm">
+                <div className="flex items-center justify-between">
+                  <span className="font-medium">{log.stage}</span>
+                  <span className={log.result === GateResult.pass ? "text-emerald-700" : "text-rose-700"}>{log.result}</span>
+                </div>
+                {log.failCode && <div className="text-xs text-rose-600">{log.failCode} ({log.severity})</div>}
+                {log.hint && <div className="text-xs text-slate-500">{log.hint}</div>}
+              </div>
+            ))}
+            {!asset.gateLogs.length && <p className="text-sm text-slate-500">No logs</p>}
+          </div>
+        </div>
+
+        <div className="card">
+          <h2 className="section-title">Add gate log</h2>
+          <form className="grid gap-2" action={createQualityGateLog}>
+            <input type="hidden" name="assetId" value={asset.id} />
+            <label className="text-sm">Date<input type="date" name="date" required className="w-full rounded border px-3 py-2" /></label>
+            <label className="text-sm">Stage
+              <select name="stage" className="w-full rounded border px-3 py-2">
+                {Object.values(GateStage).map((s) => (
+                  <option key={s} value={s}>{s}</option>
+                ))}
+              </select>
+            </label>
+            <label className="text-sm">Result
+              <select name="result" className="w-full rounded border px-3 py-2">
+                {Object.values(GateResult).map((r) => (
+                  <option key={r} value={r}>{r}</option>
+                ))}
+              </select>
+            </label>
+            <label className="text-sm">Fail code<input name="failCode" className="w-full rounded border px-3 py-2" /></label>
+            <label className="text-sm">Severity<input name="severity" className="w-full rounded border px-3 py-2" /></label>
+            <label className="text-sm">Hint<textarea name="hint" className="w-full rounded border px-3 py-2" /></label>
+            <label className="text-sm">Gate version<input name="gateVersion" className="w-full rounded border px-3 py-2" /></label>
+            <button type="submit" className="rounded bg-slate-900 px-4 py-2 text-white">Save</button>
+          </form>
+        </div>
+      </div>
+
+      <div className="card">
+        <h2 className="section-title">Log KPI</h2>
+        <form className="grid gap-3 md:grid-cols-4" action={createMetric}>
+          <input type="hidden" name="productId" value={asset.productId} />
+          <input type="hidden" name="assetId" value={asset.id} />
+          <label className="text-sm">Date<input type="date" name="date" required className="w-full rounded border px-3 py-2" /></label>
+          <label className="text-sm">Metric
+            <select name="metricKey" className="w-full rounded border px-3 py-2">
+              {Object.values(MetricKey).map((k) => (
+                <option key={k} value={k}>{k}</option>
+              ))}
+            </select>
+          </label>
+          <label className="text-sm">Value<input type="number" step="any" name="value" required className="w-full rounded border px-3 py-2" /></label>
+          <label className="text-sm">Source<input name="source" className="w-full rounded border px-3 py-2" /></label>
+          <div className="md:col-span-4">
+            <button type="submit" className="rounded bg-indigo-700 px-4 py-2 text-white">Add metric</button>
+          </div>
+        </form>
+      </div>
+
+      <div className="card">
+        <h2 className="section-title">Decision history</h2>
+        <div className="space-y-2">
+          {decisions.map((d) => (
+            <div key={d.id} className="rounded border border-slate-200 px-3 py-2 text-sm">
+              <div className="flex items-center justify-between">
+                <span className="font-medium">{d.action}</span>
+                <span className="text-xs text-slate-500">{d.date.toISOString().slice(0,10)}</span>
+              </div>
+              <div>{d.reason}</div>
+            </div>
+          ))}
+          {!decisions.length && <p className="text-sm text-slate-500">No decisions yet.</p>}
+        </div>
+        <form className="mt-4 grid gap-2" action={createDecision}>
+          <input type="hidden" name="targetType" value="asset" />
+          <input type="hidden" name="targetId" value={asset.id} />
+          <label className="text-sm">Action
+            <select name="action" className="w-full rounded border px-3 py-2">
+              {Object.values(DecisionAction).map((a) => (
+                <option key={a} value={a}>{a}</option>
+              ))}
+            </select>
+          </label>
+          <label className="text-sm">Reason<textarea name="reason" className="w-full rounded border px-3 py-2" /></label>
+          <button type="submit" className="rounded bg-teal-700 px-4 py-2 text-white">Add decision</button>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/app/assets/page.tsx
+++ b/app/assets/page.tsx
@@ -1,0 +1,38 @@
+import { prisma } from "@/lib/prisma";
+import { GateResult } from "@prisma/client";
+
+export default async function AssetsPage() {
+  const assets = await prisma.asset.findMany({
+    include: {
+      product: true,
+      gateLogs: true,
+    },
+    orderBy: { publishedAt: "desc" },
+  });
+
+  return (
+    <div className="space-y-6">
+      <h1 className="text-2xl font-semibold">Assets</h1>
+      <div className="grid gap-4 md:grid-cols-2">
+        {assets.map((asset) => {
+          const fails = asset.gateLogs.filter((g) => g.result === GateResult.fail).length;
+          const passes = asset.gateLogs.filter((g) => g.result === GateResult.pass).length;
+          return (
+            <div key={asset.id} className="card space-y-2">
+              <div className="flex items-center justify-between">
+                <div>
+                  <p className="text-lg font-semibold">{asset.title}</p>
+                  <p className="text-sm text-slate-500">{asset.product.name} / tpl: {asset.templateId ?? "-"}</p>
+                </div>
+                <a href={`/assets/${asset.id}`} className="text-sm text-teal-700 hover:underline">Detail</a>
+              </div>
+              <div className="text-xs text-slate-600">
+                Gate: {passes} pass / {fails} fail
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/app/compare/page.tsx
+++ b/app/compare/page.tsx
@@ -1,0 +1,51 @@
+import { getProposals } from "@/lib/benchmarks";
+import { getKpiPair, metricLabel } from "@/lib/kpis";
+import { ProductKind } from "@prisma/client";
+
+export default async function ComparePage() {
+  const proposals = await getProposals();
+
+  return (
+    <div className="space-y-6">
+      <div className="space-y-2">
+        <h1 className="text-2xl font-semibold">Compare & Benchmarks</h1>
+        <p className="text-sm text-slate-600">
+          BenchA: same segment + template top 20% median (N=10). BenchB: product median of last 10.
+        </p>
+      </div>
+      <div className="grid gap-4 md:grid-cols-2">
+        {proposals.map((p) => {
+          const [k1, k2] = getKpiPair(p.product.kind as ProductKind);
+          return (
+            <div key={p.asset.id} className="card space-y-3">
+              <div className="flex items-start justify-between">
+                <div className="space-y-1">
+                  <p className="font-semibold text-slate-900">{p.asset.title}</p>
+                  <p className="text-xs text-slate-500">{p.product.name} / tpl: {p.asset.templateId ?? "-"}</p>
+                </div>
+                <span className="rounded-full bg-slate-900/5 px-3 py-1 text-xs font-semibold uppercase text-slate-700">
+                  {p.suggestedAction ?? "review"}
+                </span>
+              </div>
+              <div className="grid gap-2 sm:grid-cols-2">
+                {[k1, k2].map((k) => (
+                  <div key={k} className="rounded border border-slate-200 bg-white p-2 text-sm">
+                    <div className="font-medium text-slate-900">{metricLabel(k)}</div>
+                    <div className="text-xs text-slate-500">
+                      BenchA: {p.benchmarks[k].benchA ?? "-"} / BenchB: {p.benchmarks[k].benchB ?? "-"}
+                    </div>
+                    <div className="text-slate-800">Current: {p.benchmarks[k].latest ?? "-"}</div>
+                  </div>
+                ))}
+              </div>
+              <div className="flex items-center justify-between text-xs text-slate-500">
+                <span>Gate fail rate: {(p.failRate * 100).toFixed(1)}%</span>
+                <span className="rounded-full bg-emerald-50 px-2 py-1 text-[11px] uppercase text-emerald-700">Bench tracking</span>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/app/decisions/page.tsx
+++ b/app/decisions/page.tsx
@@ -1,0 +1,81 @@
+import { approveProposal, createDecision } from "@/lib/actions";
+import { getProposals } from "@/lib/benchmarks";
+import { prisma } from "@/lib/prisma";
+import { DecisionAction } from "@prisma/client";
+
+export default async function DecisionsPage() {
+  const proposals = await getProposals();
+  const history = await prisma.decision.findMany({ orderBy: { date: "desc" } });
+
+  const approveActions = Object.fromEntries(
+    proposals.map((p) => [p.asset.id, async () => {
+      "use server";
+      await approveProposal(p.asset.id);
+    }]),
+  );
+
+  return (
+    <div className="space-y-6">
+      <div className="space-y-2">
+        <h1 className="text-2xl font-semibold">Decisions</h1>
+        <p className="text-sm text-slate-600">自動提案を承認するか、手動で意思決定を追加できます。</p>
+      </div>
+
+      <div className="card">
+        <h2 className="section-title">Proposed actions</h2>
+        <div className="grid gap-3 md:grid-cols-2">
+          {proposals.map((p) => (
+            <div key={p.asset.id} className="rounded-lg border border-slate-200 bg-slate-50 p-3 text-sm">
+              <div className="flex items-center justify-between">
+                <div className="space-y-0.5">
+                  <p className="font-semibold text-slate-900">{p.asset.title}</p>
+                  <p className="text-xs text-slate-500">{p.product.name}</p>
+                </div>
+                <span className="rounded-full bg-white px-3 py-1 text-xs font-semibold uppercase text-slate-700 shadow-sm">{p.suggestedAction ?? "review"}</span>
+              </div>
+              <p className="mt-1 text-slate-600">{p.reason ?? "Need more data"}</p>
+              <p className="text-xs text-slate-500">Gate fail rate {(p.failRate * 100).toFixed(1)}%</p>
+              <form action={approveActions[p.asset.id]} className="mt-3 flex justify-end">
+                <button type="submit" className="rounded bg-emerald-700 px-3 py-1 text-white">Approve</button>
+              </form>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      <div className="card">
+        <h2 className="section-title">Decision log</h2>
+        <div className="space-y-2">
+          {history.map((d) => (
+            <div key={d.id} className="rounded border border-slate-200 px-3 py-2 text-sm">
+              <div className="flex items-center justify-between">
+                <div>
+                  <span className="font-semibold">{d.action}</span> → {d.targetType} {d.targetId}
+                </div>
+                <span className="text-xs text-slate-500">{d.date.toISOString().slice(0,10)}</span>
+              </div>
+              <div>{d.reason}</div>
+            </div>
+          ))}
+          {!history.length && <p className="text-sm text-slate-500">No decisions logged yet.</p>}
+        </div>
+
+        <form className="mt-4 grid gap-2 md:grid-cols-3" action={createDecision}>
+          <label className="text-sm">Target type<input name="targetType" defaultValue="asset" className="w-full rounded border px-3 py-2" /></label>
+          <label className="text-sm">Target ID<input name="targetId" required className="w-full rounded border px-3 py-2" /></label>
+          <label className="text-sm">Action
+            <select name="action" className="w-full rounded border px-3 py-2">
+              {Object.values(DecisionAction).map((a) => (
+                <option key={a} value={a}>{a}</option>
+              ))}
+            </select>
+          </label>
+          <label className="text-sm md:col-span-3">Reason<textarea name="reason" className="w-full rounded border px-3 py-2" /></label>
+          <div className="md:col-span-3">
+            <button type="submit" className="rounded bg-slate-900 px-4 py-2 text-white">Add manual decision</button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,0 +1,27 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+body {
+  @apply bg-slate-50 text-slate-900;
+}
+
+.card {
+  @apply bg-white rounded-lg border border-slate-200 shadow-sm p-4;
+}
+
+.section-title {
+  @apply text-lg font-semibold mb-3;
+}
+
+@layer base {
+  label {
+    @apply text-sm text-slate-700;
+  }
+
+  input,
+  select,
+  textarea {
+    @apply rounded border border-slate-200 px-3 py-2 shadow-inner focus:border-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-200;
+  }
+}

--- a/app/import/page.tsx
+++ b/app/import/page.tsx
@@ -1,0 +1,46 @@
+import { importCsv } from "@/lib/actions";
+
+function ImportForm({ title, type, sample }: { title: string; type: string; sample: string }) {
+  return (
+    <div className="card">
+      <h3 className="section-title">{title}</h3>
+      <form action={importCsv} className="space-y-3" encType="multipart/form-data">
+        <input type="hidden" name="type" value={type} />
+        <input type="file" name="file" accept=".csv" className="w-full" required />
+        <button type="submit" className="rounded bg-slate-900 px-4 py-2 text-white">Upload CSV</button>
+      </form>
+      <p className="mt-2 text-xs text-slate-500">Sample: {sample}</p>
+    </div>
+  );
+}
+
+export default async function ImportPage() {
+  return (
+    <div className="space-y-6">
+      <h1 className="text-2xl font-semibold">CSV Import</h1>
+      <p className="text-sm text-slate-600">Upload daily metrics, costs, trends, and gate logs for batch ingestion.</p>
+      <div className="grid gap-4 md:grid-cols-2">
+        <ImportForm
+          title="metrics_daily"
+          type="metrics"
+          sample="product_id,asset_id,date,metric_key,value,source"
+        />
+        <ImportForm
+          title="trends_daily"
+          type="trends"
+          sample="date,source,topic,score,region,notes"
+        />
+        <ImportForm
+          title="costs_daily"
+          type="costs"
+          sample="product_id,asset_id,date,minutes,yen,notes"
+        />
+        <ImportForm
+          title="gates logs"
+          type="gates"
+          sample="asset_id,date,stage,result,failCode,severity,hint,gateVersion"
+        />
+      </div>
+    </div>
+  );
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,0 +1,35 @@
+import type { Metadata } from "next";
+import type { ReactNode } from "react";
+import Link from "next/link";
+import "./globals.css";
+import { NavBar } from "@/components/NavBar";
+
+export const metadata: Metadata = {
+  title: "Product Intelligence OS",
+  description: "KPI benchmarking and trend pipeline for multi-product ops",
+};
+
+export default function RootLayout({
+  children,
+}: {
+  children: ReactNode;
+}) {
+  return (
+    <html lang="en">
+      <body className="min-h-screen bg-slate-50">
+        <header className="border-b bg-white/80 backdrop-blur">
+          <div className="mx-auto flex max-w-6xl flex-col gap-3 px-6 py-4 sm:flex-row sm:items-center sm:justify-between">
+            <div>
+              <Link href="/" className="text-xl font-bold text-slate-900">
+                Product Intelligence OS
+              </Link>
+              <p className="text-sm text-slate-500">Unified KPIs, benchmarks, decisions, and trends</p>
+            </div>
+            <NavBar />
+          </div>
+        </header>
+        <main className="mx-auto max-w-6xl space-y-6 px-6 py-6">{children}</main>
+      </body>
+    </html>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,0 +1,150 @@
+import { prisma } from "@/lib/prisma";
+import { getProposals } from "@/lib/benchmarks";
+import { MetricChart } from "@/components/MetricChart";
+import { MetricKey, GateResult } from "@prisma/client";
+import { StatCard } from "@/components/StatCard";
+
+async function getTotals() {
+  const revenue = await prisma.metricDaily.aggregate({
+    where: { metricKey: MetricKey.revenue },
+    _sum: { value: true },
+  });
+  const costMinutes = await prisma.metricDaily.aggregate({
+    where: { metricKey: MetricKey.cost_minutes },
+    _sum: { value: true },
+  });
+  return {
+    revenue: revenue._sum.value ?? 0,
+    costMinutes: costMinutes._sum.value ?? 0,
+  };
+}
+
+async function getSeries(metricKey: MetricKey) {
+  const grouped = await prisma.metricDaily.groupBy({
+    by: ["date"],
+    where: { metricKey },
+    _sum: { value: true },
+    orderBy: { date: "asc" },
+  });
+  return grouped.map((g) => ({
+    date: g.date.toISOString().slice(0, 10),
+    value: g._sum.value ?? 0,
+  }));
+}
+
+async function getGateAlerts() {
+  const fails = await prisma.qualityGateLog.groupBy({
+    by: ["stage"],
+    where: { result: GateResult.fail },
+    _count: { _all: true },
+  });
+  return fails.sort((a, b) => b._count._all - a._count._all);
+}
+
+export default async function OverviewPage() {
+  const [totals, revenueSeries, costSeries, proposals, gateAlerts] = await Promise.all([
+    getTotals(),
+    getSeries(MetricKey.revenue),
+    getSeries(MetricKey.cost_minutes),
+    getProposals(),
+    getGateAlerts(),
+  ]);
+
+  const replicate = proposals.filter((p) => p.suggestedAction === "replicate").length;
+  const improve = proposals.filter((p) => p.suggestedAction === "improve").length;
+  const freeze = proposals.filter((p) => p.suggestedAction === "freeze").length;
+
+  return (
+    <div className="space-y-8">
+      <section className="space-y-3">
+        <div>
+          <h1 className="text-3xl font-semibold text-slate-900">Dashboard</h1>
+          <p className="text-sm text-slate-600">
+            最新のKPIサマリと自動提案を確認し、ワンクリックでアクションを決められます。
+          </p>
+        </div>
+        <div className="grid gap-4 md:grid-cols-4">
+          <StatCard
+            label="Total revenue"
+            value={`¥${totals.revenue.toLocaleString()}`}
+            helper="全期間の累計"
+            icon={<span>¥</span>}
+          />
+          <StatCard
+            label="Total cost (minutes)"
+            value={`${totals.costMinutes.toLocaleString()} m`}
+            helper="投入工数の合計"
+            icon={<span>⏱️</span>}
+          />
+          <StatCard
+            label="Winning (replicate)"
+            value={replicate}
+            helper="ベンチA超えの本数"
+            icon={<span>🏆</span>}
+          />
+          <StatCard
+            label="Improve / Freeze"
+            value={
+              <span className="text-lg font-semibold text-slate-900">
+                {improve} 改善 / {freeze} 凍結
+              </span>
+            }
+            helper="警告が出ているアセット"
+            icon={<span>⚠️</span>}
+          />
+        </div>
+      </section>
+
+      <section className="grid gap-4 md:grid-cols-2">
+        <MetricChart title="Revenue by date" data={revenueSeries} />
+        <MetricChart title="Cost minutes by date" data={costSeries} />
+      </section>
+
+      <section className="grid gap-4 lg:grid-cols-3">
+        <div className="card lg:col-span-2">
+          <div className="flex items-center justify-between">
+            <h3 className="section-title">Decision proposals</h3>
+            <span className="rounded-full bg-slate-900/5 px-3 py-1 text-xs text-slate-600">
+              Replicate / Improve / Freeze を自動判定
+            </span>
+          </div>
+          <div className="space-y-3">
+            {proposals.map((p) => (
+              <div key={p.asset.id} className="rounded-lg border border-slate-200 bg-slate-50 px-3 py-2">
+                <div className="flex items-center justify-between">
+                  <div>
+                    <p className="font-semibold text-slate-900">{p.asset.title}</p>
+                    <p className="text-xs text-slate-500">{p.product.name}</p>
+                  </div>
+                  <span className="rounded-full bg-white px-3 py-1 text-xs font-semibold uppercase text-slate-700 shadow-sm">
+                    {p.suggestedAction ?? "review"}
+                  </span>
+                </div>
+                <p className="mt-1 text-sm text-slate-600">{p.reason ?? "Waiting for more data"}</p>
+                <p className="text-xs text-slate-500">Gate fail rate: {(p.failRate * 100).toFixed(1)}%</p>
+              </div>
+            ))}
+            {!proposals.length && <p className="text-sm text-slate-500">まだ提案がありません。</p>}
+          </div>
+        </div>
+        <div className="card">
+          <h3 className="section-title">Quality gate alerts</h3>
+          <div className="space-y-2">
+            {gateAlerts.map((alert) => (
+              <div key={alert.stage} className="flex items-center justify-between rounded border border-slate-200 px-3 py-2">
+                <div className="flex flex-col">
+                  <span className="font-semibold text-slate-900">{alert.stage}</span>
+                  <span className="text-xs text-slate-500">失敗が多いステージ</span>
+                </div>
+                <span className="rounded-full bg-rose-50 px-3 py-1 text-xs font-semibold text-rose-700">
+                  {alert._count._all} fails
+                </span>
+              </div>
+            ))}
+            {!gateAlerts.length && <p className="text-sm text-slate-500">No fails logged</p>}
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/app/products/[id]/page.tsx
+++ b/app/products/[id]/page.tsx
@@ -1,0 +1,136 @@
+import { MetricChart } from "@/components/MetricChart";
+import { createAsset, createMetric } from "@/lib/actions";
+import { getKpiPair, metricLabel } from "@/lib/kpis";
+import { prisma } from "@/lib/prisma";
+import { AssetKind, MetricKey, ProductKind } from "@prisma/client";
+import { notFound } from "next/navigation";
+
+function seriesForKey(metrics: { metricKey: MetricKey; value: number; date: Date }[], key: MetricKey) {
+  return metrics
+    .filter((m) => m.metricKey === key)
+    .sort((a, b) => a.date.getTime() - b.date.getTime())
+    .map((m) => ({ date: m.date.toISOString().slice(0, 10), value: m.value }));
+}
+
+export default async function ProductDetail({ params }: { params: { id: string } }) {
+  const product = await prisma.product.findUnique({
+    where: { id: params.id },
+    include: {
+      metrics: true,
+      assets: true,
+    },
+  });
+  if (!product) return notFound();
+
+  const [k1, k2] = getKpiPair(product.kind as ProductKind);
+  const s1 = seriesForKey(product.metrics, k1);
+  const s2 = seriesForKey(product.metrics, k2);
+
+  const templates = await prisma.template.findMany({ where: { segment: product.segment } });
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-semibold">{product.name}</h1>
+          <p className="text-sm text-slate-500">{product.segment} / {product.kind}</p>
+        </div>
+      </div>
+
+      <div className="grid gap-4 md:grid-cols-2">
+        <MetricChart title={metricLabel(k1)} data={s1} />
+        <MetricChart title={metricLabel(k2)} data={s2} />
+      </div>
+
+      <div className="card">
+        <h2 className="section-title">Assets</h2>
+        <div className="space-y-3">
+          {product.assets.map((asset) => (
+            <div key={asset.id} className="flex items-center justify-between rounded border border-slate-200 px-3 py-2">
+              <div>
+                <p className="font-semibold">{asset.title}</p>
+                <p className="text-xs text-slate-500">{asset.kind} / tpl: {asset.templateId ?? "-"}</p>
+              </div>
+              <a href={`/assets/${asset.id}`} className="text-sm text-teal-700 hover:underline">Detail</a>
+            </div>
+          ))}
+          {!product.assets.length && <p className="text-sm text-slate-500">No assets yet.</p>}
+        </div>
+      </div>
+
+      <div className="card">
+        <h2 className="section-title">Add asset</h2>
+        <form className="grid gap-3 md:grid-cols-3" action={createAsset}>
+          <input type="hidden" name="productId" value={product.id} />
+          <label className="text-sm">
+            Title
+            <input name="title" required className="w-full rounded border px-3 py-2" />
+          </label>
+          <label className="text-sm">
+            Template
+            <select name="templateId" className="w-full rounded border px-3 py-2">
+              <option value="">(none)</option>
+              {templates.map((t) => (
+                <option key={t.id} value={t.id}>{t.name}</option>
+              ))}
+            </select>
+          </label>
+          <label className="text-sm">
+            Kind
+            <select name="kind" className="w-full rounded border px-3 py-2">
+              {Object.values(AssetKind).map((k) => (
+                <option key={k} value={k}>{k}</option>
+              ))}
+            </select>
+          </label>
+          <label className="text-sm">
+            Published at
+            <input name="publishedAt" type="date" className="w-full rounded border px-3 py-2" />
+          </label>
+          <div className="md:col-span-3">
+            <button type="submit" className="rounded bg-teal-700 px-4 py-2 text-white">Save</button>
+          </div>
+        </form>
+      </div>
+
+      <div className="card">
+        <h2 className="section-title">Log KPI</h2>
+        <form className="grid gap-3 md:grid-cols-4" action={createMetric}>
+          <input type="hidden" name="productId" value={product.id} />
+          <label className="text-sm">
+            Asset (optional)
+            <select name="assetId" className="w-full rounded border px-3 py-2">
+              <option value="">(product level)</option>
+              {product.assets.map((a) => (
+                <option key={a.id} value={a.id}>{a.title}</option>
+              ))}
+            </select>
+          </label>
+          <label className="text-sm">
+            Date
+            <input type="date" name="date" required className="w-full rounded border px-3 py-2" />
+          </label>
+          <label className="text-sm">
+            Metric
+            <select name="metricKey" className="w-full rounded border px-3 py-2">
+              {Object.values(MetricKey).map((k) => (
+                <option key={k} value={k}>{k}</option>
+              ))}
+            </select>
+          </label>
+          <label className="text-sm">
+            Value
+            <input type="number" step="any" name="value" required className="w-full rounded border px-3 py-2" />
+          </label>
+          <label className="text-sm">
+            Source
+            <input name="source" placeholder="manual" className="w-full rounded border px-3 py-2" />
+          </label>
+          <div className="md:col-span-4">
+            <button type="submit" className="rounded bg-slate-900 px-4 py-2 text-white">Add metric</button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/app/products/page.tsx
+++ b/app/products/page.tsx
@@ -1,0 +1,92 @@
+import { createProduct } from "@/lib/actions";
+import { getKpiPair, metricLabel } from "@/lib/kpis";
+import { prisma } from "@/lib/prisma";
+import { MetricKey, ProductKind } from "@prisma/client";
+
+function latestMetricValue(metrics: { metricKey: MetricKey; value: number; date: Date }[], key: MetricKey) {
+  const found = metrics
+    .filter((m) => m.metricKey === key)
+    .sort((a, b) => b.date.getTime() - a.date.getTime())[0];
+  return found?.value ?? null;
+}
+
+export default async function ProductsPage() {
+  const products = await prisma.product.findMany({
+    include: {
+      assets: true,
+      metrics: true,
+    },
+  });
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-semibold">Products</h1>
+      </div>
+
+      <div className="grid gap-4 md:grid-cols-2">
+        {products.map((product) => {
+          const [k1, k2] = getKpiPair(product.kind as ProductKind);
+          const v1 = latestMetricValue(product.metrics, k1);
+          const v2 = latestMetricValue(product.metrics, k2);
+          return (
+            <div key={product.id} className="card space-y-2">
+              <div className="flex items-center justify-between">
+                <div>
+                  <h2 className="text-lg font-semibold">{product.name}</h2>
+                  <p className="text-sm text-slate-500">{product.segment} / {product.kind}</p>
+                </div>
+                <a href={`/products/${product.id}`} className="text-sm text-teal-700 hover:underline">
+                  View
+                </a>
+              </div>
+              <div className="flex gap-6 text-sm text-slate-700">
+                <div>
+                  <div className="text-xs text-slate-500">{metricLabel(k1)}</div>
+                  <div className="font-semibold">{v1 ?? "-"}</div>
+                </div>
+                <div>
+                  <div className="text-xs text-slate-500">{metricLabel(k2)}</div>
+                  <div className="font-semibold">{v2 ?? "-"}</div>
+                </div>
+                <div>
+                  <div className="text-xs text-slate-500">Assets</div>
+                  <div className="font-semibold">{product.assets.length}</div>
+                </div>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+
+      <div className="card">
+        <h2 className="section-title">Add product</h2>
+        <form className="grid gap-3 md:grid-cols-4" action={createProduct}>
+          <label className="text-sm">
+            ID (optional)
+            <input name="id" className="w-full rounded border px-3 py-2" placeholder="auto" />
+          </label>
+          <label className="text-sm">
+            Name
+            <input name="name" required className="w-full rounded border px-3 py-2" />
+          </label>
+          <label className="text-sm">
+            Segment
+            <input name="segment" required className="w-full rounded border px-3 py-2" />
+          </label>
+          <label className="text-sm">
+            Kind
+            <select name="kind" className="w-full rounded border px-3 py-2">
+              {Object.values(ProductKind).map((k) => (
+                <option key={k} value={k}>{k}</option>
+              ))}
+            </select>
+          </label>
+          <div className="md:col-span-4">
+            <button type="submit" className="rounded bg-teal-700 px-4 py-2 text-white">Save</button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/app/templates/page.tsx
+++ b/app/templates/page.tsx
@@ -1,0 +1,41 @@
+import { createTemplate } from "@/lib/actions";
+import { prisma } from "@/lib/prisma";
+
+export default async function TemplatesPage() {
+  const templates = await prisma.template.findMany({ orderBy: { updatedAt: "desc" } });
+
+  return (
+    <div className="space-y-6">
+      <h1 className="text-2xl font-semibold">Templates</h1>
+
+      <div className="grid gap-4 md:grid-cols-2">
+        {templates.map((tpl) => (
+          <div key={tpl.id} className="card space-y-1">
+            <div className="flex items-center justify-between">
+              <div>
+                <p className="font-semibold">{tpl.name}</p>
+                <p className="text-xs text-slate-500">{tpl.segment}</p>
+              </div>
+              <span className="text-xs text-slate-500">{tpl.updatedAt.toISOString().slice(0,10)}</span>
+            </div>
+            {tpl.description && <p className="text-sm text-slate-600">{tpl.description}</p>}
+            <p className="text-xs text-slate-500">ID: {tpl.id}</p>
+          </div>
+        ))}
+      </div>
+
+      <div className="card">
+        <h2 className="section-title">Add / Update template</h2>
+        <form className="grid gap-3 md:grid-cols-4" action={createTemplate}>
+          <label className="text-sm">ID (optional)<input name="id" className="w-full rounded border px-3 py-2" placeholder="auto" /></label>
+          <label className="text-sm">Name<input name="name" required className="w-full rounded border px-3 py-2" /></label>
+          <label className="text-sm">Segment<input name="segment" required className="w-full rounded border px-3 py-2" /></label>
+          <label className="text-sm md:col-span-4">Description<textarea name="description" className="w-full rounded border px-3 py-2" placeholder="Hook/葛藤/転換 など" /></label>
+          <div className="md:col-span-4">
+            <button type="submit" className="rounded bg-teal-700 px-4 py-2 text-white">Save template</button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/app/trends/page.tsx
+++ b/app/trends/page.tsx
@@ -1,0 +1,75 @@
+import { createTrend } from "@/lib/actions";
+import { prisma } from "@/lib/prisma";
+
+function buildCandidates(trends: { topic: string; segment?: string | null }[], templates: { id: string; name: string; segment: string }[]) {
+  const candidates: { topic: string; template: string; idea: string }[] = [];
+  for (const trend of trends) {
+    for (const tpl of templates) {
+      if (!trend.segment || trend.segment === tpl.segment || tpl.segment === "ai") {
+        candidates.push({
+          topic: trend.topic,
+          template: tpl.name,
+          idea: `${trend.topic} × ${tpl.name} の候補を3パターン作成`,
+        });
+      }
+    }
+  }
+  return candidates.slice(0, 20);
+}
+
+export default async function TrendsPage() {
+  const trends = await prisma.trendDaily.findMany({ orderBy: { date: "desc" } });
+  const templates = await prisma.template.findMany();
+  const candidates = buildCandidates(trends, templates);
+
+  return (
+    <div className="space-y-6">
+      <h1 className="text-2xl font-semibold">Trends</h1>
+
+      <div className="grid gap-4 md:grid-cols-2">
+        <div className="card">
+          <h2 className="section-title">Trend list</h2>
+          <div className="space-y-2">
+            {trends.map((t) => (
+              <div key={t.id} className="rounded border border-slate-200 px-3 py-2 text-sm">
+                <div className="flex items-center justify-between">
+                  <span className="font-semibold">{t.topic}</span>
+                  <span className="text-xs text-slate-500">{t.date.toISOString().slice(0,10)}</span>
+                </div>
+                <div className="text-xs text-slate-500">{t.source} / {t.region ?? ""}</div>
+                {t.notes && <div className="text-xs text-slate-600">{t.notes}</div>}
+              </div>
+            ))}
+            {!trends.length && <p className="text-sm text-slate-500">No trends yet.</p>}
+          </div>
+        </div>
+        <div className="card">
+          <h2 className="section-title">Add trend</h2>
+          <form className="grid gap-2" action={createTrend}>
+            <label className="text-sm">Date<input type="date" name="date" required className="w-full rounded border px-3 py-2" /></label>
+            <label className="text-sm">Topic<input name="topic" required className="w-full rounded border px-3 py-2" /></label>
+            <label className="text-sm">Source<input name="source" placeholder="manual/rss/csv" className="w-full rounded border px-3 py-2" /></label>
+            <label className="text-sm">Score<input type="number" step="any" name="score" className="w-full rounded border px-3 py-2" /></label>
+            <label className="text-sm">Region<input name="region" className="w-full rounded border px-3 py-2" /></label>
+            <label className="text-sm">Notes<textarea name="notes" className="w-full rounded border px-3 py-2" /></label>
+            <button type="submit" className="rounded bg-slate-900 px-4 py-2 text-white">Save</button>
+          </form>
+        </div>
+      </div>
+
+      <div className="card">
+        <h2 className="section-title">Trend × Template candidates</h2>
+        <div className="grid gap-2 md:grid-cols-2">
+          {candidates.map((c, idx) => (
+            <div key={`${c.topic}-${c.template}-${idx}`} className="rounded border border-slate-200 p-3 text-sm">
+              <p className="font-semibold">{c.topic}</p>
+              <p className="text-slate-600">Template: {c.template}</p>
+              <p className="text-xs text-slate-500">{c.idea}</p>
+            </div>
+          ))}
+          {!candidates.length && <p className="text-sm text-slate-500">No candidates yet.</p>}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/MetricChart.tsx
+++ b/components/MetricChart.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import { Area, AreaChart, CartesianGrid, ResponsiveContainer, Tooltip, XAxis, YAxis } from "recharts";
+
+export type MetricPoint = {
+  date: string;
+  value: number;
+};
+
+export function MetricChart({ title, data }: { title: string; data: MetricPoint[] }) {
+  return (
+    <div className="card">
+      <h3 className="section-title">{title}</h3>
+      <div className="h-64">
+        <ResponsiveContainer width="100%" height="100%">
+          <AreaChart data={data} margin={{ left: 6, right: 6 }}>
+            <defs>
+              <linearGradient id="colorValue" x1="0" y1="0" x2="0" y2="1">
+                <stop offset="5%" stopColor="#0f766e" stopOpacity={0.4} />
+                <stop offset="95%" stopColor="#0f766e" stopOpacity={0} />
+              </linearGradient>
+            </defs>
+            <CartesianGrid strokeDasharray="3 3" />
+            <XAxis dataKey="date" tick={{ fontSize: 12 }} />
+            <YAxis tick={{ fontSize: 12 }} />
+            <Tooltip />
+            <Area type="monotone" dataKey="value" stroke="#0f766e" fillOpacity={1} fill="url(#colorValue)" />
+          </AreaChart>
+        </ResponsiveContainer>
+      </div>
+    </div>
+  );
+}

--- a/components/NavBar.tsx
+++ b/components/NavBar.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+
+const navItems = [
+  { href: "/", label: "Overview" },
+  { href: "/products", label: "Products" },
+  { href: "/assets", label: "Assets" },
+  { href: "/compare", label: "Compare" },
+  { href: "/trends", label: "Trends" },
+  { href: "/decisions", label: "Decisions" },
+  { href: "/templates", label: "Templates" },
+  { href: "/import", label: "Import" },
+];
+
+export function NavBar() {
+  const pathname = usePathname();
+  return (
+    <nav className="flex flex-wrap items-center gap-2 text-sm">
+      {navItems.map((item) => {
+        const active =
+          item.href === "/" ? pathname === item.href : pathname.startsWith(item.href);
+        return (
+          <Link
+            key={item.href}
+            href={item.href}
+            className={`rounded-lg px-3 py-1 transition ${
+              active
+                ? "bg-slate-900 text-white shadow-sm"
+                : "border border-transparent text-slate-700 hover:border-slate-200 hover:bg-slate-100"
+            }`}
+          >
+            {item.label}
+          </Link>
+        );
+      })}
+    </nav>
+  );
+}

--- a/components/StatCard.tsx
+++ b/components/StatCard.tsx
@@ -1,0 +1,26 @@
+import type { ReactNode } from "react";
+
+export function StatCard({
+  label,
+  value,
+  helper,
+  icon,
+}: {
+  label: string;
+  value: ReactNode;
+  helper?: string;
+  icon?: ReactNode;
+}) {
+  return (
+    <div className="card flex items-start gap-3">
+      <div className="flex h-10 w-10 items-center justify-center rounded-full bg-slate-900/5 text-lg text-slate-700">
+        {icon ?? "•"}
+      </div>
+      <div className="flex flex-col gap-1">
+        <span className="text-xs uppercase tracking-wide text-slate-500">{label}</span>
+        <span className="text-2xl font-semibold text-slate-900">{value}</span>
+        {helper && <span className="text-xs text-slate-500">{helper}</span>}
+      </div>
+    </div>
+  );
+}

--- a/lib/actions.ts
+++ b/lib/actions.ts
@@ -1,0 +1,299 @@
+"use server";
+
+import { parse } from "csv-parse/sync";
+import { revalidatePath } from "next/cache";
+import {
+  AssetKind,
+  DecisionAction,
+  GateResult,
+  GateStage,
+  MetricKey,
+  Prisma,
+  ProductKind,
+} from "@prisma/client";
+import { prisma } from "./prisma";
+import { getKpiPair } from "./kpis";
+import { buildProposal } from "./benchmarks";
+
+function uuid() {
+  return crypto.randomUUID();
+}
+
+export async function createProduct(formData: FormData) {
+  const id = (formData.get("id") as string) || uuid();
+  const name = (formData.get("name") as string)?.trim();
+  const segment = (formData.get("segment") as string)?.trim();
+  const kind = formData.get("kind") as ProductKind;
+  if (!name || !segment || !kind) return;
+  await prisma.product.upsert({
+    where: { id },
+    update: { name, segment, kind },
+    create: { id, name, segment, kind },
+  });
+  revalidatePath("/products");
+  revalidatePath("/");
+}
+
+export async function createTemplate(formData: FormData) {
+  const id = (formData.get("id") as string) || uuid();
+  const name = (formData.get("name") as string)?.trim();
+  const segment = (formData.get("segment") as string)?.trim();
+  const description = (formData.get("description") as string) || undefined;
+  if (!name || !segment) return;
+  await prisma.template.upsert({
+    where: { id },
+    update: { name, segment, description },
+    create: { id, name, segment, description },
+  });
+  revalidatePath("/templates");
+}
+
+export async function createAsset(formData: FormData) {
+  const id = (formData.get("id") as string) || uuid();
+  const title = (formData.get("title") as string)?.trim();
+  const productId = formData.get("productId") as string;
+  const templateId = (formData.get("templateId") as string) || undefined;
+  const kind = (formData.get("kind") as AssetKind) ?? AssetKind.video;
+  const publishedAt = formData.get("publishedAt") as string;
+  if (!title || !productId) return;
+  await prisma.asset.upsert({
+    where: { id },
+    update: {
+      title,
+      productId,
+      templateId,
+      kind,
+      publishedAt: publishedAt ? new Date(publishedAt) : null,
+    },
+    create: {
+      id,
+      title,
+      productId,
+      templateId,
+      kind,
+      publishedAt: publishedAt ? new Date(publishedAt) : null,
+    },
+  });
+  revalidatePath("/assets");
+  revalidatePath(`/products/${productId}`);
+}
+
+export async function createTrend(formData: FormData) {
+  const id = (formData.get("id") as string) || uuid();
+  const date = formData.get("date") as string;
+  const source = (formData.get("source") as string) || "manual";
+  const topic = (formData.get("topic") as string)?.trim();
+  const score = formData.get("score") as string;
+  const region = (formData.get("region") as string) || undefined;
+  const notes = (formData.get("notes") as string) || undefined;
+  if (!date || !topic) return;
+  await prisma.trendDaily.upsert({
+    where: { id },
+    update: {
+      date: new Date(date),
+      source,
+      topic,
+      score: score ? Number(score) : null,
+      region,
+      notes,
+    },
+    create: {
+      id,
+      date: new Date(date),
+      source,
+      topic,
+      score: score ? Number(score) : null,
+      region,
+      notes,
+    },
+  });
+  revalidatePath("/trends");
+}
+
+export async function createDecision(formData: FormData) {
+  const targetType = (formData.get("targetType") as string) ?? "asset";
+  const targetId = formData.get("targetId") as string;
+  const action = formData.get("action") as DecisionAction;
+  const reason = (formData.get("reason") as string) || "";
+  if (!targetId || !action) return;
+  await prisma.decision.create({
+    data: {
+      id: uuid(),
+      date: new Date(),
+      targetType,
+      targetId,
+      action,
+      reason,
+      payload: formData.get("payload") as string,
+    },
+  });
+  revalidatePath("/decisions");
+}
+
+export async function createQualityGateLog(formData: FormData) {
+  const assetId = formData.get("assetId") as string;
+  const date = formData.get("date") as string;
+  const stage = formData.get("stage") as GateStage;
+  const result = formData.get("result") as GateResult;
+  const failCode = (formData.get("failCode") as string) || undefined;
+  const severity = (formData.get("severity") as string) || undefined;
+  const hint = (formData.get("hint") as string) || undefined;
+  const gateVersion = (formData.get("gateVersion") as string) || undefined;
+  if (!assetId || !date || !stage || !result) return;
+  await prisma.qualityGateLog.create({
+    data: {
+      id: uuid(),
+      assetId,
+      date: new Date(date),
+      stage,
+      result,
+      failCode,
+      severity,
+      hint,
+      gateVersion,
+    },
+  });
+  revalidatePath("/assets");
+  revalidatePath(`/assets/${assetId}`);
+}
+
+export async function createMetric(formData: FormData) {
+  const productId = formData.get("productId") as string;
+  const assetId = (formData.get("assetId") as string) || undefined;
+  const date = formData.get("date") as string;
+  const metricKey = formData.get("metricKey") as MetricKey;
+  const value = formData.get("value") as string;
+  const source = (formData.get("source") as string) || "manual";
+  if (!productId || !date || !metricKey || !value) return;
+  await prisma.metricDaily.create({
+    data: {
+      id: uuid(),
+      productId,
+      assetId,
+      date: new Date(date),
+      metricKey,
+      value: Number(value),
+      source,
+    },
+  });
+  revalidatePath("/assets");
+  revalidatePath(`/products/${productId}`);
+}
+
+export async function importCsv(formData: FormData) {
+  const file = formData.get("file");
+  const type = formData.get("type") as string;
+  if (!file || !(file instanceof File)) return { imported: 0, errors: ["ファイルが選択されていません"] };
+
+  const buffer = Buffer.from(await file.arrayBuffer());
+  const text = buffer.toString("utf-8");
+  const records = parse(text, { columns: true, skip_empty_lines: true, trim: true });
+  let imported = 0;
+  const errors: string[] = [];
+
+  for (const [index, row] of records.entries()) {
+    try {
+      if (type === "metrics") {
+        const data: Prisma.MetricDailyCreateInput = {
+          id: row.id || uuid(),
+          product: { connect: { id: row.product_id } },
+          asset: row.asset_id ? { connect: { id: row.asset_id } } : undefined,
+          date: new Date(row.date),
+          metricKey: row.metric_key as MetricKey,
+          value: Number(row.value),
+          source: row.source || "import",
+        };
+        await prisma.metricDaily.upsert({
+          where: { id: data.id },
+          update: data,
+          create: data,
+        });
+      } else if (type === "trends") {
+        await prisma.trendDaily.upsert({
+          where: { id: (row.id as string) || uuid() },
+          update: {
+            date: new Date(row.date),
+            source: row.source,
+            topic: row.topic,
+            score: row.score ? Number(row.score) : null,
+            region: row.region,
+            notes: row.notes,
+          },
+          create: {
+            id: (row.id as string) || uuid(),
+            date: new Date(row.date),
+            source: row.source,
+            topic: row.topic,
+            score: row.score ? Number(row.score) : null,
+            region: row.region,
+            notes: row.notes,
+          },
+        });
+      } else if (type === "costs") {
+        const data: Prisma.CostDailyCreateInput = {
+          id: row.id || uuid(),
+          product: { connect: { id: row.product_id } },
+          asset: row.asset_id ? { connect: { id: row.asset_id } } : undefined,
+          date: new Date(row.date),
+          minutes: row.minutes ? Number(row.minutes) : null,
+          yen: row.yen ? Number(row.yen) : null,
+          notes: row.notes,
+        };
+        await prisma.costDaily.upsert({ where: { id: data.id }, update: data, create: data });
+      } else if (type === "gates") {
+        await prisma.qualityGateLog.upsert({
+          where: { id: (row.id as string) || uuid() },
+          update: {
+            asset: { connect: { id: row.asset_id } },
+            date: new Date(row.date),
+            stage: row.stage as GateStage,
+            result: row.result as GateResult,
+            failCode: row.failCode || row.fail_code,
+            severity: row.severity,
+            hint: row.hint,
+            gateVersion: row.gateVersion || row.gate_version,
+          },
+          create: {
+            id: (row.id as string) || uuid(),
+            asset: { connect: { id: row.asset_id } },
+            date: new Date(row.date),
+            stage: row.stage as GateStage,
+            result: row.result as GateResult,
+            failCode: row.failCode || row.fail_code,
+            severity: row.severity,
+            hint: row.hint,
+            gateVersion: row.gateVersion || row.gate_version,
+          },
+        });
+      }
+      imported += 1;
+    } catch (error) {
+      console.error(error);
+      errors.push(`row ${index + 1}: ${String((error as Error).message)}`);
+    }
+  }
+
+  revalidatePath("/import");
+  return { imported, errors };
+}
+
+export async function approveProposal(assetId: string) {
+  const asset = await prisma.asset.findUnique({ where: { id: assetId }, include: { product: true } });
+  if (!asset || !asset.product) return;
+  const proposal = await buildProposal(asset, asset.product);
+  if (!proposal.suggestedAction) return;
+  const [k1, k2] = getKpiPair(asset.product.kind);
+  const reason = proposal.reason ?? "Auto proposal";
+  await prisma.decision.create({
+    data: {
+      id: uuid(),
+      date: new Date(),
+      targetType: "asset",
+      targetId: asset.id,
+      action: proposal.suggestedAction,
+      reason,
+      payload: JSON.stringify({ kpis: [k1, k2], failRate: proposal.failRate, benchmarks: proposal.benchmarks }),
+    },
+  });
+  revalidatePath("/decisions");
+}

--- a/lib/benchmarks.ts
+++ b/lib/benchmarks.ts
@@ -1,0 +1,154 @@
+import { Asset, DecisionAction, GateResult, MetricKey, Product, ProductKind } from "@prisma/client";
+import { prisma } from "./prisma";
+import { getKpiPair } from "./kpis";
+
+function median(values: number[]): number | null {
+  if (!values.length) return null;
+  const sorted = [...values].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 0
+    ? (sorted[mid - 1] + sorted[mid]) / 2
+    : sorted[mid];
+}
+
+function topPercentileMedian(values: number[], percentile = 0.2): number | null {
+  if (!values.length) return null;
+  const count = Math.max(1, Math.ceil(values.length * percentile));
+  const top = [...values].sort((a, b) => b - a).slice(0, count);
+  return median(top);
+}
+
+async function getBenchA(
+  templateId: string | null | undefined,
+  segment: string,
+  metricKey: MetricKey,
+  limit = 10,
+): Promise<number | null> {
+  if (!templateId) return null;
+  const metrics = await prisma.metricDaily.findMany({
+    where: {
+      metricKey,
+      asset: {
+        templateId,
+        product: { segment },
+      },
+    },
+    orderBy: { date: "desc" },
+    take: limit,
+  });
+  return topPercentileMedian(metrics.map((m) => m.value));
+}
+
+async function getBenchB(productId: string, metricKey: MetricKey, limit = 10): Promise<number | null> {
+  const metrics = await prisma.metricDaily.findMany({
+    where: { productId, metricKey },
+    orderBy: { date: "desc" },
+    take: limit,
+  });
+  return median(metrics.map((m) => m.value));
+}
+
+async function getLatestMetrics(assetId: string, productId: string, keys: MetricKey[]) {
+  const entries = await prisma.metricDaily.findMany({
+    where: { assetId, productId, metricKey: { in: keys } },
+    orderBy: { date: "desc" },
+  });
+  const grouped: Record<MetricKey, number | null> = Object.fromEntries(keys.map((k) => [k, null]));
+  keys.forEach((key) => {
+    const value = entries.find((m) => m.metricKey === key);
+    grouped[key] = value?.value ?? null;
+  });
+  return grouped;
+}
+
+async function getFailRate(assetId: string, window = 10): Promise<number> {
+  const logs = await prisma.qualityGateLog.findMany({
+    where: { assetId },
+    orderBy: { date: "desc" },
+    take: window,
+  });
+  if (!logs.length) return 0;
+  const fails = logs.filter((l) => l.result === GateResult.fail).length;
+  return fails / logs.length;
+}
+
+async function belowBenchTwice(assetId: string, productId: string, key: MetricKey, bench: number | null) {
+  if (bench == null) return false;
+  const entries = await prisma.metricDaily.findMany({
+    where: { assetId, productId, metricKey: key },
+    orderBy: { date: "desc" },
+    take: 2,
+  });
+  return entries.length === 2 && entries.every((e) => e.value < bench);
+}
+
+export type Proposal = {
+  asset: Asset;
+  product: Product;
+  benchmarks: Record<MetricKey, { benchA: number | null; benchB: number | null; latest: number | null }>;
+  failRate: number;
+  suggestedAction?: DecisionAction;
+  reason?: string;
+};
+
+export async function buildProposal(asset: Asset, product: Product): Promise<Proposal> {
+  const [k1, k2] = getKpiPair(product.kind as ProductKind);
+  const keys: MetricKey[] = [k1, k2];
+  const [benchA1, benchA2, benchB1, benchB2, latest] = await Promise.all([
+    getBenchA(asset.templateId, product.segment, k1),
+    getBenchA(asset.templateId, product.segment, k2),
+    getBenchB(product.id, k1),
+    getBenchB(product.id, k2),
+    getLatestMetrics(asset.id, product.id, keys),
+  ]);
+  const failRate = await getFailRate(asset.id);
+
+  const benchmarks: Proposal["benchmarks"] = {
+    [k1]: { benchA: benchA1, benchB: benchB1, latest: latest[k1] },
+    [k2]: { benchA: benchA2, benchB: benchB2, latest: latest[k2] },
+  } as Proposal["benchmarks"];
+
+  let suggestedAction: DecisionAction | undefined;
+  let reason: string | undefined;
+
+  const bothAboveA =
+    benchmarks[k1].benchA != null && benchmarks[k2].benchA != null &&
+    benchmarks[k1].latest != null && benchmarks[k2].latest != null &&
+    benchmarks[k1].latest! >= benchmarks[k1].benchA! &&
+    benchmarks[k2].latest! >= benchmarks[k2].benchA!;
+
+  const underB =
+    (benchmarks[k1].benchB != null && benchmarks[k1].latest != null && benchmarks[k1].latest! < benchmarks[k1].benchB!) ||
+    (benchmarks[k2].benchB != null && benchmarks[k2].latest != null && benchmarks[k2].latest! < benchmarks[k2].benchB!);
+
+  const freezeCandidate =
+    (await belowBenchTwice(asset.id, product.id, k1, benchmarks[k1].benchB)) &&
+    (await belowBenchTwice(asset.id, product.id, k2, benchmarks[k2].benchB));
+
+  if (bothAboveA && failRate < 0.1) {
+    suggestedAction = DecisionAction.replicate;
+    reason = "KPI1+KPI2 exceed BenchA and gate fail rate < 10%.";
+  } else if (freezeCandidate) {
+    suggestedAction = DecisionAction.freeze;
+    reason = "Last two runs fell below BenchB for both KPIs.";
+  } else if (underB || failRate >= 0.2) {
+    suggestedAction = DecisionAction.improve;
+    reason = underB
+      ? "KPI below BenchB median."
+      : "Gate fail rate >= 20%.";
+  }
+
+  return {
+    asset,
+    product,
+    benchmarks,
+    failRate,
+    suggestedAction,
+    reason,
+  };
+}
+
+export async function getProposals(): Promise<Proposal[]> {
+  const assets = await prisma.asset.findMany({ include: { product: true } });
+  return Promise.all(assets.map((asset) => buildProposal(asset, asset.product)));
+}

--- a/lib/kpis.ts
+++ b/lib/kpis.ts
@@ -1,0 +1,37 @@
+import { MetricKey, ProductKind } from "@prisma/client";
+
+export const KPI_PAIR_BY_KIND: Record<ProductKind, [MetricKey, MetricKey]> = {
+  [ProductKind.youtube]: [MetricKey.ctr, MetricKey.avg_view_percentage],
+  [ProductKind.note]: [MetricKey.paid_conversions, MetricKey.churn_rate],
+  [ProductKind.app]: [MetricKey.d7_retention, MetricKey.arpu],
+  [ProductKind.music]: [MetricKey.revenue, MetricKey.cost_minutes],
+  [ProductKind.other]: [MetricKey.revenue, MetricKey.cost_minutes],
+};
+
+export function getKpiPair(kind: ProductKind): [MetricKey, MetricKey] {
+  return KPI_PAIR_BY_KIND[kind] ?? [MetricKey.revenue, MetricKey.cost_minutes];
+}
+
+export function metricLabel(key: MetricKey): string {
+  const map: Partial<Record<MetricKey, string>> = {
+    revenue: "Revenue",
+    cost_minutes: "Cost (minutes)",
+    cost_yen: "Cost (yen)",
+    views: "Views",
+    impressions: "Impressions",
+    ctr: "CTR",
+    avg_view_duration_sec: "Avg View Duration (sec)",
+    avg_view_percentage: "Avg View %",
+    subscribers_delta: "Subscribers Δ",
+    article_views: "Article Views",
+    paid_conversions: "Paid Conversions",
+    churn_rate: "Churn Rate",
+    installs: "Installs",
+    dau: "DAU",
+    d1_retention: "D1 Retention",
+    d7_retention: "D7 Retention",
+    arpu: "ARPU",
+    mrr: "MRR",
+  };
+  return map[key] ?? key;
+}

--- a/lib/prisma.ts
+++ b/lib/prisma.ts
@@ -1,0 +1,11 @@
+import { PrismaClient } from "@prisma/client";
+
+const globalForPrisma = global as unknown as { prisma: PrismaClient | undefined };
+
+export const prisma =
+  globalForPrisma.prisma ??
+  new PrismaClient({
+    log: ["warn", "error"],
+  });
+
+if (process.env.NODE_ENV !== "production") globalForPrisma.prisma = prisma;

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,0 +1,10 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  experimental: {
+    serverActions: {
+      bodySizeLimit: '10mb',
+    },
+  },
+};
+
+export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "product-intelligence-os",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Product Intelligence OS built with Next.js, Prisma, and SQLite",
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint",
+    "prisma:generate": "prisma generate",
+    "prisma:db-push": "prisma db push",
+    "prisma:seed": "prisma db seed"
+  },
+  "dependencies": {
+    "@prisma/client": "^5.22.0",
+    "clsx": "^2.1.0",
+    "csv-parse": "^5.5.6",
+    "next": "^14.2.7",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "recharts": "^2.12.7",
+    "zod": "^3.23.8"
+  },
+  "devDependencies": {
+    "@types/node": "^22.7.5",
+    "@types/react": "^18.3.10",
+    "@types/react-dom": "^18.3.0",
+    "autoprefixer": "^10.4.20",
+    "eslint": "^8.57.1",
+    "eslint-config-next": "^14.2.7",
+    "postcss": "^8.4.41",
+    "prisma": "^5.22.0",
+    "tailwindcss": "^3.4.14",
+    "ts-node": "^10.9.2",
+    "typescript": "^5.6.3"
+  },
+  "prisma": {
+    "seed": "ts-node --esm prisma/seed.ts"
+  },
+  "type": "module"
+}

--- a/postcss.config.mjs
+++ b/postcss.config.mjs
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,0 +1,182 @@
+datasource db {
+  provider = "sqlite"
+  url      = "file:./dev.db"
+}
+
+generator client {
+  provider = "prisma-client-js"
+}
+
+enum ProductKind {
+  youtube
+  note
+  app
+  music
+  other
+}
+
+enum AssetKind {
+  video
+  article
+  app_release
+  other
+}
+
+enum MetricKey {
+  // 共通
+  revenue
+  cost_minutes
+  cost_yen
+
+  // YouTube
+  views
+  impressions
+  ctr
+  avg_view_duration_sec
+  avg_view_percentage
+  subscribers_delta
+
+  // note
+  article_views
+  paid_conversions
+  churn_rate
+
+  // app
+  installs
+  dau
+  d1_retention
+  d7_retention
+  arpu
+  mrr
+}
+
+enum GateStage {
+  script
+  image_prompt
+  tts
+  edit
+  upload
+}
+
+enum GateResult {
+  pass
+  fail
+}
+
+enum DecisionAction {
+  replicate
+  improve
+  freeze
+  kill
+}
+
+model Product {
+  id        String      @id
+  kind      ProductKind
+  name      String
+  segment   String      // romance/emotion/comedy/ai etc
+  owner     String?
+  createdAt DateTime    @default(now())
+
+  assets    Asset[]
+  metrics   MetricDaily[]
+  costs     CostDaily[]
+}
+
+model Asset {
+  id          String   @id
+  productId   String
+  kind        AssetKind
+  title       String
+  templateId  String?  // 勝ち型テンプレID
+  publishedAt DateTime?
+
+  product     Product  @relation(fields: [productId], references: [id])
+  metrics     MetricDaily[]
+  costs       CostDaily[]
+  gateLogs    QualityGateLog[]
+}
+
+model MetricDaily {
+  id         String    @id
+  productId  String
+  assetId    String?
+  date       DateTime
+  metricKey  MetricKey
+  value      Float
+  source     String    // manual/import/api
+
+  product    Product   @relation(fields: [productId], references: [id])
+  asset      Asset?    @relation(fields: [assetId], references: [id])
+
+  @@index([productId, date, metricKey])
+  @@index([assetId, date, metricKey])
+}
+
+model CostDaily {
+  id        String   @id
+  productId String
+  assetId   String?
+  date      DateTime
+  minutes   Float?
+  yen       Float?
+  notes     String?
+
+  product   Product  @relation(fields: [productId], references: [id])
+  asset     Asset?   @relation(fields: [assetId], references: [id])
+
+  @@index([productId, date])
+  @@index([assetId, date])
+}
+
+model QualityGateLog {
+  id          String     @id
+  assetId     String
+  date        DateTime
+  stage       GateStage
+  result      GateResult
+  failCode    String?
+  severity    String?    // high/mid/low
+  hint        String?
+  gateVersion String?
+
+  asset       Asset      @relation(fields: [assetId], references: [id])
+
+  @@index([assetId, date])
+  @@index([stage, result])
+}
+
+model TrendDaily {
+  id     String   @id
+  date   DateTime
+  source String   // manual/rss/csv
+  topic  String
+  score  Float?
+  region String?
+  notes  String?
+
+  @@index([date])
+  @@index([topic])
+}
+
+model Decision {
+  id         String         @id
+  date       DateTime
+  targetType String         // product/asset/template
+  targetId   String
+  action     DecisionAction
+  reason     String
+  payload    String?        // JSON string
+
+  @@index([date])
+  @@index([targetType, targetId])
+}
+
+model Template {
+  id          String   @id
+  name        String
+  segment     String
+  description String?
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+}

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,0 +1,185 @@
+import { PrismaClient, AssetKind, MetricKey, ProductKind, GateStage, GateResult, DecisionAction } from "@prisma/client";
+
+const prisma = new PrismaClient();
+
+async function main() {
+  await prisma.qualityGateLog.deleteMany();
+  await prisma.decision.deleteMany();
+  await prisma.costDaily.deleteMany();
+  await prisma.metricDaily.deleteMany();
+  await prisma.asset.deleteMany();
+  await prisma.template.deleteMany();
+  await prisma.product.deleteMany();
+  await prisma.trendDaily.deleteMany();
+
+  const products = [
+    { id: "yt_ai", kind: ProductKind.youtube, name: "AI解説CH", segment: "ai" },
+    { id: "yt_love", kind: ProductKind.youtube, name: "恋愛アニメCH", segment: "romance" },
+    { id: "yt_emotion", kind: ProductKind.youtube, name: "感動アニメCH", segment: "emotion" },
+    { id: "yt_comedy", kind: ProductKind.youtube, name: "コメディCH", segment: "comedy" },
+    { id: "note_main", kind: ProductKind.note, name: "note本体", segment: "ai" },
+    { id: "app_factory", kind: ProductKind.app, name: "アプリ量産", segment: "tools" },
+  ];
+
+  const templates = [
+    { id: "tpl_rom_001", name: "すれ違い→逆転", segment: "romance" },
+    { id: "tpl_emo_001", name: "喪失→回復", segment: "emotion" },
+    { id: "tpl_com_001", name: "勘違い連鎖", segment: "comedy" },
+    { id: "tpl_ai_001", name: "最新AI解説10分", segment: "ai" },
+  ];
+
+  await Promise.all(products.map((p) => prisma.product.create({ data: p })));
+  await Promise.all(templates.map((t) => prisma.template.create({ data: t })));
+
+  const assets = [
+    {
+      id: "yt_ai_ep01",
+      productId: "yt_ai",
+      kind: AssetKind.video,
+      title: "GPUの仕組みを図解",
+      templateId: "tpl_ai_001",
+      publishedAt: new Date("2024-12-20"),
+    },
+    {
+      id: "yt_love_ep01",
+      productId: "yt_love",
+      kind: AssetKind.video,
+      title: "冬のすれ違いラブストーリー",
+      templateId: "tpl_rom_001",
+      publishedAt: new Date("2024-12-22"),
+    },
+    {
+      id: "note_ai_001",
+      productId: "note_main",
+      kind: AssetKind.article,
+      title: "生成AIのUIパターン10選",
+      templateId: "tpl_ai_001",
+      publishedAt: new Date("2024-12-18"),
+    },
+  ];
+
+  await Promise.all(assets.map((a) => prisma.asset.create({ data: a })));
+
+  const today = new Date();
+  const metrics = [
+    // YouTube AI
+    { productId: "yt_ai", assetId: "yt_ai_ep01", metricKey: MetricKey.ctr, value: 0.085 },
+    { productId: "yt_ai", assetId: "yt_ai_ep01", metricKey: MetricKey.avg_view_percentage, value: 0.62 },
+    { productId: "yt_ai", assetId: "yt_ai_ep01", metricKey: MetricKey.views, value: 120000 },
+    // YouTube love
+    { productId: "yt_love", assetId: "yt_love_ep01", metricKey: MetricKey.ctr, value: 0.11 },
+    { productId: "yt_love", assetId: "yt_love_ep01", metricKey: MetricKey.avg_view_percentage, value: 0.71 },
+    { productId: "yt_love", assetId: "yt_love_ep01", metricKey: MetricKey.views, value: 84000 },
+    // note
+    { productId: "note_main", assetId: "note_ai_001", metricKey: MetricKey.paid_conversions, value: 46 },
+    { productId: "note_main", assetId: "note_ai_001", metricKey: MetricKey.churn_rate, value: 0.06 },
+    // common revenue/cost
+    { productId: "yt_ai", assetId: "yt_ai_ep01", metricKey: MetricKey.revenue, value: 92000 },
+    { productId: "yt_ai", assetId: "yt_ai_ep01", metricKey: MetricKey.cost_minutes, value: 420 },
+    { productId: "yt_love", assetId: "yt_love_ep01", metricKey: MetricKey.revenue, value: 78000 },
+    { productId: "yt_love", assetId: "yt_love_ep01", metricKey: MetricKey.cost_minutes, value: 360 },
+  ];
+
+  await prisma.metricDaily.createMany({
+    data: metrics.map((m, idx) => ({
+      ...m,
+      id: `metric_${idx}`,
+      date: new Date(today.getTime() - idx * 24 * 60 * 60 * 1000),
+      source: "seed",
+    })),
+  });
+
+  await prisma.costDaily.createMany({
+    data: [
+      {
+        id: "cost_yt_ai",
+        productId: "yt_ai",
+        assetId: "yt_ai_ep01",
+        date: today,
+        minutes: 420,
+        yen: 18000,
+        notes: "script + edit",
+      },
+      {
+        id: "cost_yt_love",
+        productId: "yt_love",
+        assetId: "yt_love_ep01",
+        date: today,
+        minutes: 360,
+        yen: 15000,
+        notes: "voice + color",
+      },
+    ],
+  });
+
+  await prisma.trendDaily.createMany({
+    data: [
+      {
+        id: "trend_001",
+        date: today,
+        source: "manual",
+        topic: "年末の別れ",
+        score: 0.82,
+        region: "JP",
+        notes: "SNSキーワード急増",
+      },
+      {
+        id: "trend_002",
+        date: today,
+        source: "rss",
+        topic: "AI音声キャラ",
+        score: 0.74,
+        region: "JP",
+        notes: "音声アプリ特集",
+      },
+    ],
+  });
+
+  await prisma.qualityGateLog.createMany({
+    data: [
+      {
+        id: "gate_1",
+        assetId: "yt_ai_ep01",
+        date: today,
+        stage: GateStage.script,
+        result: GateResult.pass,
+        failCode: null,
+        severity: null,
+        hint: "構成OK",
+        gateVersion: "v1",
+      },
+      {
+        id: "gate_2",
+        assetId: "yt_love_ep01",
+        date: today,
+        stage: GateStage.image_prompt,
+        result: GateResult.fail,
+        failCode: "img_style",
+        severity: "mid",
+        hint: "表情バリエ不足",
+        gateVersion: "v1",
+      },
+    ],
+  });
+
+  await prisma.decision.create({
+    data: {
+      id: "decision_seed",
+      date: today,
+      targetType: "asset",
+      targetId: "yt_ai_ep01",
+      action: DecisionAction.replicate,
+      reason: "CTR + retention exceed benchmark; gate pass",
+      payload: JSON.stringify({ source: "seed" }),
+    },
+  });
+}
+
+main()
+  .catch((e) => {
+    console.error(e);
+    process.exit(1);
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,0 +1,11 @@
+import type { Config } from "tailwindcss";
+
+const config: Config = {
+  content: ["./app/**/*.{js,ts,jsx,tsx}", "./components/**/*.{js,ts,jsx,tsx}"],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};
+
+export default config;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "esnext",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "types": ["node"],
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- add a reusable NavBar and stat card component plus base form styling to create a cohesive UI
- refresh the overview dashboard layout with highlighted KPI cards and reorganized proposal/gate alert sections
- polish compare and decisions screens with clearer cards and helper copy for benchmarked actions

## Testing
- npm install *(fails: registry 403 in this environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694236fa9578832fabba9d4567db6d47)